### PR TITLE
Enables multi-threaded approach

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,85 @@
+use std::{
+    thread,
+    sync::{
+        mpsc,
+        Arc,
+        Mutex
+    },
+};
+
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+pub struct Threadpool {
+    workers: Vec<Worker>,
+    sender: Option<mpsc::Sender<Job>>,
+}
+
+impl Threadpool {
+    pub fn new(size: usize) -> Threadpool {
+        assert!(size > 0);
+
+        let mut workers = Vec::with_capacity(size);
+        let (sender, receiver) = mpsc::channel();
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        for id in 0..size {
+            workers.push(Worker::new(id, Arc::clone(&receiver)));
+        }
+
+        Threadpool { 
+            workers, 
+            sender: Some(sender) 
+        }
+    }
+    pub fn execute<F, T>(&self, f: F) -> mpsc::Receiver<T> 
+        where F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static {
+            let (_sender, _receiver) = mpsc::channel();
+            let job = Box::new(move || {
+               let result = f();
+               _sender.send(result).unwrap();
+            });
+            self.sender.as_ref().unwrap().send(job).unwrap();
+            _receiver
+    }
+}
+
+impl Drop for Threadpool {
+    fn drop(&mut self) {
+        drop(self.sender.take());
+        for worker in &mut self.workers {
+            println!("Shutting down worker: {}", worker.id);
+            if let Some(thread) = worker.thread.take() {
+                thread.join().unwrap();
+            }
+        }
+    }
+}
+
+struct Worker {
+    id: usize,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Worker {
+    fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Job>>>) -> Worker {
+        let thread = thread::spawn(move || {
+            loop {
+                let message = receiver.lock().unwrap().recv();
+                match message {
+                    Ok(job) => {
+                        job();
+                    }
+                    Err(_) => {
+                        println!("Worker {id} is shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+        Worker {
+            id, 
+            thread: Some(thread),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,29 @@
 use std::{fs, io::Write};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use dirs::home_dir;
 use scraper::{Element, Html, Selector};
+
+use james_clear_3_2_1::Threadpool;
 
 const URL: &str = "https://jamesclear.com/3-2-1";
 const H2_TAG_TEXT: &str = "1 QUESTION FOR YOU";
 const P_TAG: &str = "p";
 
-fn get_questions(doc: &Html, sel: &Selector) -> Result<Option<String>> {
-    for h2_element in doc.select(sel) {
+fn get_questions(doc: Html, sel: Selector) -> Result<Option<String>> {
+    for h2_element in doc.select(&sel) {
         if h2_element.text().collect::<String>() == H2_TAG_TEXT {
             let mut p_element = h2_element
                 .next_sibling_element()
                 .with_context(|| format!("Couldn't find the question! {doc:#?}"))?;
-            let mut questions = String::new();
+            let mut question = String::new();
             while p_element.value().name() == P_TAG {
                 let text = p_element.text().collect::<String>();
                 if text.starts_with("Until") {
                     break;
                 } else {
-                    questions.push_str(&text);
-                    questions.push(' ');
+                    question.push_str(&text);
+                    question.push(' ');
                     if let Some(next_element) = p_element.next_sibling_element() {
                         p_element = next_element;
                     } else {
@@ -29,7 +31,7 @@ fn get_questions(doc: &Html, sel: &Selector) -> Result<Option<String>> {
                     }
                 }
             }
-            return Ok(Some(questions));
+            return Ok(Some(question));
         }
     }
     Ok(None)
@@ -55,19 +57,42 @@ fn main() -> Result<()> {
     let main_page = fetch_html_doc(URL)?;
     let main_html = Html::parse_document(&main_page);
     let a_selector = Selector::parse(r#"a[class="all-articles__news__post"]"#).unwrap();
-
+    
+    let pool = Threadpool::new(4);
+    let mut receivers = vec![];
     for element in main_html.select(&a_selector) {
-        if let Some(newsletter_url) = element.value().attr("href") {
-            let newsletter = fetch_html_doc(&newsletter_url)?;
-            let newsletter_html = Html::parse_document(&newsletter);
-            let h2_selector = Selector::parse("h2").unwrap();
-            if let Some(mut questions) = get_questions(&newsletter_html, &h2_selector)? {
-                questions.push('\n');
-                file_obj
-                    .write_all(questions.as_bytes())
-                    .expect("Unable to write to file");
+        let href = element.value().attr("href").map(String::from);
+        let receiver = pool.execute(move || {
+            if let Some(newsletter_url) = href {
+                let newsletter = fetch_html_doc(&newsletter_url)?;
+                let newsletter_html = Html::parse_document(&newsletter);
+                let h2_selector = Selector::parse("h2").unwrap();
+                get_questions(newsletter_html, h2_selector)
+            } else {
+                Err(anyhow!("No URL found!"))
             }
-        };
+        });
+        receivers.push(receiver);
+    }
+    
+    for receiver in receivers {
+        match receiver.recv() {
+            Ok(Ok(Some(mut question))) => {
+                question.push('\n');
+                if let Err(err) = file_obj.write_all(question.as_bytes()) {
+                    println!("Failed to write to file: {err}");
+                }
+            }
+            Ok(Ok(None)) => {
+                // No question returned — skip silently or log
+            }
+            Ok(Err(err)) => {
+                println!("Error in get_questions: {err}");
+            }
+            Err(err) => {
+                println!("Failed to receive from channel: {err}");
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
This change adds multi-threaded support for scrapping all the questions using a Threadpool as explained [here](https://doc.rust-lang.org/book/ch21-02-multithreaded.html)